### PR TITLE
Fix Terraformer's maven from breaking GH actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ group = project.maven_group
 
 repositories {
 	maven { url = "https://maven.gegy.dev/" }
-	maven { url = "https://maven.terraformersmc.com/" }
+	maven { url = "https://raw.githubusercontent.com/TerraformersMC/Archive/main/releases/" }
 	maven { url = "https://aperlambda.github.io/maven" }
 	maven { url = "https://hephaestus.dev/release" }
 	maven { url = "https://storage.googleapis.com/devan-maven/" }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ group = project.maven_group
 
 repositories {
 	maven { url = "https://maven.gegy.dev/" }
-	maven { url = "https://raw.githubusercontent.com/TerraformersMC/Archive/main/releases/" }
+	maven { url = "https://raw.githubusercontent.com/TerraformersMC/Archive/main/releases" }
 	maven { url = "https://aperlambda.github.io/maven" }
 	maven { url = "https://hephaestus.dev/release" }
 	maven { url = "https://storage.googleapis.com/devan-maven/" }


### PR DESCRIPTION
simple fix, just redirect to the github repo for now