### PR TITLE
Update ForgeSlopeBakedModel.java to possibly fix the slope breaking crash

### DIFF
--- a/forge/src/main/java/io/github/foundationgames/automobility/forge/block/render/ForgeSlopeBakedModel.java
+++ b/forge/src/main/java/io/github/foundationgames/automobility/forge/block/render/ForgeSlopeBakedModel.java
@@ -79,8 +79,10 @@ public class ForgeSlopeBakedModel extends SlopeBakedModel {
         if (renderType == null || this.getRenderTypes(state, rand, data).contains(renderType)) {
             var quads = new ArrayList<BakedQuad>();
             var geo = new ForgeGeometryBuilder(this.settings.getRotation().getMatrix(), side, quads);
-
-            this.buildSlopeGeometry(data.get(FRAME_SPRITE), geo, unwrap(data.get(FRAME_COLOR)), unwrap(data.get(BORDERED_LEFT)), unwrap(data.get(BORDERED_RIGHT)));
+            
+            if (data.get(FRAME_SPRITE) != null) {
+                this.buildSlopeGeometry(data.get(FRAME_SPRITE), geo, unwrap(data.get(FRAME_COLOR)), unwrap(data.get(BORDERED_LEFT)), unwrap(data.get(BORDERED_RIGHT)));
+            }
 
             return quads;
         }


### PR DESCRIPTION

i'm not a mod developper but this seems like it could work to prevent the game from crashing when the sprite returns null

Please test on forge yourself before merging :)