### PR TITLE
Fix dedicated server crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -11,6 +11,7 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
+	mavenLocal()
 	maven { url = "https://maven.gegy.dev/" }
 	maven { url = "https://maven.terraformersmc.com/" }
 	maven { url = "https://aperlambda.github.io/maven" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx3G
 
 minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.3
-loader_version=0.14.8
+yarn_mappings=1.18.2+build.4
+loader_version=0.16.5
 
 #Fabric api
-fabric_version=0.56.0+1.18.2
+fabric_version=0.77.0+1.18.2
 
 # Other Dependencies
 midnightcontrols_version=1.4.1-1.18

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/foundationgames/automobility/automobile/AutomobileFrame.java
+++ b/src/main/java/io/github/foundationgames/automobility/automobile/AutomobileFrame.java
@@ -256,7 +256,7 @@ public record AutomobileFrame(
             float rearAttachmentPos,
             float frontAttachmentPos
     ) {
-        @Environment(EnvType.CLIENT)
+        
         public Function<EntityRendererFactory.Context, Model> model() {
             return AutomobilityModels.MODELS.get(modelId);
         }

--- a/src/main/java/io/github/foundationgames/automobility/automobile/AutomobileWheel.java
+++ b/src/main/java/io/github/foundationgames/automobility/automobile/AutomobileWheel.java
@@ -93,7 +93,7 @@ public record AutomobileWheel(
         Identifier texture,
         Identifier modelId
     ) {
-        @Environment(EnvType.CLIENT)
+        
         public Function<EntityRendererFactory.Context, Model> model() {
             return AutomobilityModels.MODELS.get(modelId);
         }

--- a/src/main/java/io/github/foundationgames/automobility/automobile/attachment/FrontAttachmentType.java
+++ b/src/main/java/io/github/foundationgames/automobility/automobile/attachment/FrontAttachmentType.java
@@ -71,7 +71,7 @@ public record FrontAttachmentType<T extends FrontAttachment>(
     }
 
     public record FrontAttachmentModel(Identifier texture, Identifier modelId, float scale) {
-        @Environment(EnvType.CLIENT)
+        
         public Function<EntityRendererFactory.Context, Model> model() {
             return AutomobilityModels.MODELS.get(modelId);
         }

--- a/src/main/java/io/github/foundationgames/automobility/automobile/attachment/RearAttachmentType.java
+++ b/src/main/java/io/github/foundationgames/automobility/automobile/attachment/RearAttachmentType.java
@@ -106,7 +106,7 @@ public record RearAttachmentType<T extends RearAttachment>(
     }
 
     public record RearAttachmentModel(Identifier texture, Identifier modelId, float pivotDistPx) {
-        @Environment(EnvType.CLIENT)
+        
         public Function<EntityRendererFactory.Context, Model> model() {
             return AutomobilityModels.MODELS.get(modelId);
         }

--- a/src/main/java/io/github/foundationgames/automobility/block/AutomobilityBlocks.java
+++ b/src/main/java/io/github/foundationgames/automobility/block/AutomobilityBlocks.java
@@ -59,7 +59,7 @@ public enum AutomobilityBlocks {;
         registerSlopes("minecraft");
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public static void initClient() {
         ColorProviderRegistry.BLOCK.register((state, world, pos, tintIndex) -> world != null && pos != null ? BiomeColors.getGrassColor(world, pos) : GrassColors.getColor(0.5D, 1.0D), GRASS_OFF_ROAD);
         ColorProviderRegistry.ITEM.register((stack, tintIndex) -> GrassColors.getColor(0.5D, 1.0D), GRASS_OFF_ROAD.asItem());

--- a/src/main/java/io/github/foundationgames/automobility/block/entity/AutomobileAssemblerBlockEntity.java
+++ b/src/main/java/io/github/foundationgames/automobility/block/entity/AutomobileAssemblerBlockEntity.java
@@ -49,11 +49,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AutomobileAssemblerBlockEntity extends BlockEntity implements RenderableAutomobile {
-    @Environment(EnvType.CLIENT) private Model frameModel = null;
-    @Environment(EnvType.CLIENT) private Model engineModel = null;
-    @Environment(EnvType.CLIENT) private Model wheelModel = null;
-    @Environment(EnvType.CLIENT) private Model emptyRearAttModel = null;
-    @Environment(EnvType.CLIENT) private Model emptyFrontAttModel = null;
+    private Model frameModel = null;
+     private Model engineModel = null;
+     private Model wheelModel = null;
+     private Model emptyRearAttModel = null;
+     private Model emptyFrontAttModel = null;
     private boolean componentsUpdated = true;
 
     protected AutomobileFrame frame = AutomobileFrame.EMPTY;

--- a/src/main/java/io/github/foundationgames/automobility/entity/AutomobileEntity.java
+++ b/src/main/java/io/github/foundationgames/automobility/entity/AutomobileEntity.java
@@ -91,15 +91,15 @@ public class AutomobileEntity extends Entity implements RenderableAutomobile, En
 
     private final AutomobileStats stats = new AutomobileStats();
 
-    @Environment(EnvType.CLIENT)
+
     private Model frameModel = null;
-    @Environment(EnvType.CLIENT)
+    
     private Model wheelModel = null;
-    @Environment(EnvType.CLIENT)
+    
     private Model engineModel = null;
-    @Environment(EnvType.CLIENT)
+    
     private @Nullable Model rearAttachmentModel = null;
-    @Environment(EnvType.CLIENT)
+    
     private @Nullable Model frontAttachmentModel = null;
 
     public static final int SMALL_TURBO_TIME = 35;
@@ -310,7 +310,7 @@ public class AutomobileEntity extends Entity implements RenderableAutomobile, En
         accelerating = (1 & d) > 0;
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public boolean updateModels = true;
 
     public AutomobileEntity(EntityType<?> type, World world) {
@@ -1116,7 +1116,7 @@ public class AutomobileEntity extends Entity implements RenderableAutomobile, En
         return (1 / ((300 * speed) + (18.5f - (stats.getAcceleration() * 5.3f)))) * (0.9f * ((stats.getAcceleration() + 1) / 2));
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public void provideClientInput(boolean fwd, boolean back, boolean left, boolean right, boolean space) {
         // Receives inputs client-side and sends them to the server
         if (!(
@@ -1250,7 +1250,7 @@ public class AutomobileEntity extends Entity implements RenderableAutomobile, En
         return ControllerUtils.inControllerMode();
     }
 
-    @Environment(EnvType.CLIENT)
+    
     private void updateModels(EntityRendererFactory.Context ctx) {
         if (updateModels) {
             this.frameModel = frame.model().model().apply(ctx);
@@ -1263,19 +1263,19 @@ public class AutomobileEntity extends Entity implements RenderableAutomobile, En
         }
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public Model getWheelModel(EntityRendererFactory.Context ctx) {
         updateModels(ctx);
         return wheelModel;
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public Model getFrameModel(EntityRendererFactory.Context ctx) {
         updateModels(ctx);
         return frameModel;
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public Model getEngineModel(EntityRendererFactory.Context ctx) {
         updateModels(ctx);
         return engineModel;

--- a/src/main/java/io/github/foundationgames/automobility/entity/AutomobilityEntities.java
+++ b/src/main/java/io/github/foundationgames/automobility/entity/AutomobilityEntities.java
@@ -57,7 +57,7 @@ public enum AutomobilityEntities {;
     public static void init() {
     }
 
-    @Environment(EnvType.CLIENT)
+
     public static void initClient() {
         EntityRendererRegistry.INSTANCE.register(AUTOMOBILE, AutomobileEntityRenderer::new);
 

--- a/src/main/java/io/github/foundationgames/automobility/item/AutomobileComponentItem.java
+++ b/src/main/java/io/github/foundationgames/automobility/item/AutomobileComponentItem.java
@@ -75,7 +75,7 @@ public class AutomobileComponentItem<T extends AutomobileComponent<T>> extends I
         }
     }
 
-    @Environment(EnvType.CLIENT)
+    
     protected boolean renders(T component) {
         return !component.isEmpty();
     }
@@ -84,7 +84,7 @@ public class AutomobileComponentItem<T extends AutomobileComponent<T>> extends I
         return !component.isEmpty();
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public void registerItemRenderer(Function<T, Model> modelProvider, Function<T, Identifier> textureProvider, ToFloatFunction<T> scaleProvider) {
         BuiltinItemRendererRegistry.INSTANCE.register(this, (stack, mode, matrices, vertexConsumers, light, overlay) -> {
             var component = this.getComponent(stack);

--- a/src/main/java/io/github/foundationgames/automobility/item/AutomobilityItems.java
+++ b/src/main/java/io/github/foundationgames/automobility/item/AutomobilityItems.java
@@ -68,16 +68,16 @@ public enum AutomobilityItems {;
         );
     }
 
-    @Environment(EnvType.CLIENT) private static EntityRendererFactory.Context cachedCtx;
-    @Environment(EnvType.CLIENT) private static final Map<AutomobileFrame, Model> frameModelPool = new HashMap<>();
-    @Environment(EnvType.CLIENT) private static final Map<AutomobileWheel, Model> wheelModelPool = new HashMap<>();
-    @Environment(EnvType.CLIENT) private static final Map<AutomobileEngine, Model> engineModelPool = new HashMap<>();
-    @Environment(EnvType.CLIENT) private static final Map<RearAttachmentType<?>, Model> rearAttModelPool = new HashMap<>();
-    @Environment(EnvType.CLIENT) private static final Map<FrontAttachmentType<?>, Model> frontAttModelPool = new HashMap<>();
+     private static EntityRendererFactory.Context cachedCtx;
+    private static final Map<AutomobileFrame, Model> frameModelPool = new HashMap<>();
+    private static final Map<AutomobileWheel, Model> wheelModelPool = new HashMap<>();
+    private static final Map<AutomobileEngine, Model> engineModelPool = new HashMap<>();
+    private static final Map<RearAttachmentType<?>, Model> rearAttModelPool = new HashMap<>();
+    private static final Map<FrontAttachmentType<?>, Model> frontAttModelPool = new HashMap<>();
 
     private static final AutomobileData reader = new AutomobileData();
 
-    @Environment(EnvType.CLIENT)
+    
     public static void initClient() {
         var itemAutomobile = new ItemRenderableAutomobile(reader);
         EntityRenderHelper.registerContextListener(ctx -> {

--- a/src/main/java/io/github/foundationgames/automobility/particle/DriftSmokeParticle.java
+++ b/src/main/java/io/github/foundationgames/automobility/particle/DriftSmokeParticle.java
@@ -32,7 +32,7 @@ public class DriftSmokeParticle extends SpriteBillboardParticle {
         return ParticleTextureSheet.PARTICLE_SHEET_TRANSLUCENT;
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public static class Factory implements ParticleFactory<DefaultParticleType> {
         private final SpriteProvider sprites;
 

--- a/src/main/java/io/github/foundationgames/automobility/render/AutomobilityModels.java
+++ b/src/main/java/io/github/foundationgames/automobility/render/AutomobilityModels.java
@@ -41,11 +41,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-@Environment(EnvType.CLIENT)
+
 public enum AutomobilityModels {;
     public static final Map<Identifier, Function<EntityRendererFactory.Context, Model>> MODELS = new HashMap<>();
 
-    @Environment(EnvType.CLIENT)
+    
     public static void init() {
         MODELS.put(Automobility.id("empty"), EmptyModel::new);
 

--- a/src/main/java/io/github/foundationgames/automobility/util/network/PayloadPackets.java
+++ b/src/main/java/io/github/foundationgames/automobility/util/network/PayloadPackets.java
@@ -23,7 +23,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
 public enum PayloadPackets {;
-    @Environment(EnvType.CLIENT)
+    
     public static void sendSyncAutomobileInputPacket(AutomobileEntity entity, boolean fwd, boolean back, boolean left, boolean right, boolean space) {
         var buf = new PacketByteBuf(Unpooled.buffer());
         buf.writeBoolean(fwd);
@@ -35,7 +35,7 @@ public enum PayloadPackets {;
         ClientPlayNetworking.send(Automobility.id("sync_automobile_inputs"), buf);
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public static void requestSyncAutomobileComponentsPacket(AutomobileEntity entity) {
         var buf = new PacketByteBuf(Unpooled.buffer());
         buf.writeInt(entity.getId());
@@ -118,7 +118,7 @@ public enum PayloadPackets {;
         });
     }
 
-    @Environment(EnvType.CLIENT)
+    
     public static void initClient() {
         ClientPlayNetworking.registerGlobalReceiver(Automobility.id("sync_automobile_data"), (client, handler, buf, responseSender) -> {
             PacketByteBuf dup = PacketByteBufs.copy(buf);


### PR DESCRIPTION
This is more or less an unconditional nuking of the `@Environment` from the sources. The game would crash on a dedicated server whenever an Automobility block was placed because of missing fields.